### PR TITLE
feat: return a bool from handle to show if the key was consumed

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
                     }
                 ];
 
-                fn handle(&mut self, event: &<::ratatui_input_manager::CrosstermBackend as ::ratatui_input_manager::Backend>::Event) {
+                fn handle(&mut self, event: &<::ratatui_input_manager::CrosstermBackend as ::ratatui_input_manager::Backend>::Event) -> bool {
                     match event {
                         ::crossterm::event::Event::Key(
                             ::crossterm::event::KeyEvent {
@@ -328,7 +328,7 @@ mod tests {
                                 kind: ::crossterm::event::KeyEventKind::Press,
                                 ..
                             },
-                        ) if modifiers.contains(::crossterm::event::KeyModifiers::NONE) => self.bar(),
+                        ) if modifiers.contains(::crossterm::event::KeyModifiers::NONE) => { self.bar(); true }
                         ::crossterm::event::Event::Key(
                             ::crossterm::event::KeyEvent {
                                 code: KeyCode::Char('q'),
@@ -336,7 +336,7 @@ mod tests {
                                 kind: ::crossterm::event::KeyEventKind::Press,
                                 ..
                             },
-                        ) if modifiers.contains(::crossterm::event::KeyModifiers::NONE) => self.bar(),
+                        ) if modifiers.contains(::crossterm::event::KeyModifiers::NONE) => { self.bar(); true }
                         ::crossterm::event::Event::Key(
                             ::crossterm::event::KeyEvent {
                                 code: KeyCode::Char('a'),
@@ -349,8 +349,8 @@ mod tests {
                                 ::crossterm::event::KeyModifiers::NONE
                                     .union(KeyModifiers::CONTROL)
                                     .union(KeyModifiers::SHIFT),
-                            ) => self.baz(),
-                        _ => {}
+                            ) => { self.baz(); true }
+                        _ => false,
                     }
                 }
             }
@@ -426,18 +426,18 @@ mod tests {
                     }
                 ];
 
-                fn handle(&mut self, event: &<::ratatui_input_manager::TermionBackend as ::ratatui_input_manager::Backend>::Event) {
+                fn handle(&mut self, event: &<::ratatui_input_manager::TermionBackend as ::ratatui_input_manager::Backend>::Event) -> bool {
                     match event {
                         ::termion::event::Event::Key(
                             ::termion::event::Key::Esc
-                        ) => self.bar(),
+                        ) => { self.bar(); true }
                         ::termion::event::Event::Key(
                             ::termion::event::Key::Char('q')
-                        ) => self.bar(),
+                        ) => { self.bar(); true }
                         ::termion::event::Event::Key(
                             ::termion::event::Key::Char('a')
-                        ) => self.baz(),
-                        _ => {}
+                        ) => { self.baz(); true }
+                        _ => false,
                     }
                 }
             }
@@ -515,20 +515,20 @@ mod tests {
                     }
                 ];
 
-                fn handle(&mut self, event: &<::ratatui_input_manager::TermwizBackend as ::ratatui_input_manager::Backend>::Event) {
+                fn handle(&mut self, event: &<::ratatui_input_manager::TermwizBackend as ::ratatui_input_manager::Backend>::Event) -> bool {
                     match event {
                         ::termwiz::input::InputEvent::Key(
                             ::termwiz::input::KeyEvent {
                                 key: KeyCode::Escape,
                                 modifiers,
                             },
-                        ) if modifiers.contains(::termwiz::input::Modifiers::NONE) => self.bar(),
+                        ) if modifiers.contains(::termwiz::input::Modifiers::NONE) => { self.bar(); true }
                         ::termwiz::input::InputEvent::Key(
                             ::termwiz::input::KeyEvent {
                                 key: KeyCode::Char('q'),
                                 modifiers,
                             },
-                        ) if modifiers.contains(::termwiz::input::Modifiers::NONE) => self.bar(),
+                        ) if modifiers.contains(::termwiz::input::Modifiers::NONE) => { self.bar(); true }
                         ::termwiz::input::InputEvent::Key(
                             ::termwiz::input::KeyEvent {
                                 key: KeyCode::Char('a'),
@@ -539,8 +539,8 @@ mod tests {
                                 ::termwiz::input::Modifiers::NONE
                                     .union(Modifiers::CTRL)
                                     .union(Modifiers::SHIFT),
-                            ) => self.baz(),
-                        _ => {}
+                            ) => { self.baz(); true }
+                        _ => false,
                     }
                 }
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -222,10 +222,10 @@ fn keymap_impl(args: KeyMapAttrs, input: ItemImpl) -> syn::Result<(ItemImpl, Ite
                 )*
             ];
 
-            fn handle(&mut self, event: &<#backend_type as ::ratatui_input_manager::Backend>::Event) {
+            fn handle(&mut self, event: &<#backend_type as ::ratatui_input_manager::Backend>::Event) -> bool {
                 match event {
-                    #(#(#match_arms => self.#fn_names(),)*)*
-                    _ => {}
+                    #(#(#match_arms => {self.#fn_names(); true},)*)*
+                    _ => false
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub trait KeyMap<B: Backend + 'static> {
     const KEYBINDS: &'static [KeyBind<B>];
 
     /// Handle an event by calling the appropriate handler method
-    fn handle(&mut self, event: &B::Event);
+    fn handle(&mut self, event: &B::Event) -> bool;
 }
 
 /// A dyn compatible equivalent to [`KeyMap`]
@@ -66,7 +66,7 @@ pub trait KeyMap<B: Backend + 'static> {
 pub trait DynKeyMap<B: Backend + 'static> {
     fn keybinds(&self) -> &'static [KeyBind<B>];
 
-    fn handle(&mut self, event: &B::Event);
+    fn handle(&mut self, event: &B::Event) -> bool;
 }
 
 impl<B: Backend + 'static, T: KeyMap<B>> DynKeyMap<B> for T {
@@ -74,7 +74,7 @@ impl<B: Backend + 'static, T: KeyMap<B>> DynKeyMap<B> for T {
         T::KEYBINDS
     }
 
-    fn handle(&mut self, event: &B::Event) {
+    fn handle(&mut self, event: &B::Event) -> bool {
         self.handle(event)
     }
 }

--- a/tests/crossterm_test.rs
+++ b/tests/crossterm_test.rs
@@ -29,7 +29,6 @@ struct TestKeyMap {
     y: bool,
 
     confirmation_overlay: Option<TestConfirmationOverlayKeyMap>,
-    submitted: bool,
 }
 
 impl TestKeyMap {
@@ -41,26 +40,13 @@ impl TestKeyMap {
     }
 
     fn handle(&mut self, event: &Event) -> bool {
-        if let Some(overlay) = &mut self.confirmation_overlay {
-            let consumed = overlay.handle(event);
-
-            if let Some(accepted) = overlay.accepted {
+        if let Some(overlay) = &mut self.confirmation_overlay
+            && overlay.handle(event) {
                 self.confirmation_overlay = None;
-                if accepted {
-                    self.submit();
-                }
-            }
-
-            if consumed {
                 return true;
             }
-        }
 
         KeyMap::handle(self, event)
-    }
-
-    fn submit(&mut self) {
-        self.submitted = true;
     }
 }
 
@@ -187,15 +173,12 @@ fn test_overlay_keybinds() {
     assert!(map.handle(&event));
     assert!(map.ctrl_shift_a);
 
-    // Overlay consumes conflicting key, submits, and is dismissed
+    // Overlay consumes conflicting key and is dismissed
     let event = Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
     assert!(map.handle(&event));
     assert!(!map.y);
-    assert!(map.submitted);
-    assert!(map.confirmation_overlay.is_none());
 
-    // With overlay dismissed, conflicting keys pass through to root
-    let event = Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+    // With overlay dismissed, conflicting key passes through to root
     assert!(map.handle(&event));
     assert!(map.y);
 }

--- a/tests/crossterm_test.rs
+++ b/tests/crossterm_test.rs
@@ -3,9 +3,65 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui_input_manager::{KeyMap, keymap};
 
 #[derive(Debug, Default, PartialEq, Eq)]
+struct TestConfirmationOverlayKeyMap {
+    accepted: Option<bool>,
+}
+
+#[keymap(backend = "crossterm")]
+impl TestConfirmationOverlayKeyMap {
+    /// Handle y to accept
+    #[keybind(pressed(key=KeyCode::Char('y')))]
+    fn handle_accept(&mut self) {
+        self.accepted = Some(true);
+    }
+
+    /// Handle n to reject
+    #[keybind(pressed(key=KeyCode::Char('n')))]
+    fn handle_reject(&mut self) {
+        self.accepted = Some(false);
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
 struct TestKeyMap {
     exit: bool,
     ctrl_shift_a: bool,
+    y: bool,
+
+    confirmation_overlay: Option<TestConfirmationOverlayKeyMap>,
+    submitted: bool,
+}
+
+impl TestKeyMap {
+    fn with_active_overlay() -> TestKeyMap {
+        TestKeyMap {
+            confirmation_overlay: Some(TestConfirmationOverlayKeyMap { accepted: None }),
+            ..Default::default()
+        }
+    }
+
+    fn handle(&mut self, event: &Event) -> bool {
+        if let Some(overlay) = &mut self.confirmation_overlay {
+            let consumed = overlay.handle(event);
+
+            if let Some(accepted) = overlay.accepted {
+                self.confirmation_overlay = None;
+                if accepted {
+                    self.submit();
+                }
+            }
+
+            if consumed {
+                return true;
+            }
+        }
+
+        KeyMap::handle(self, event)
+    }
+
+    fn submit(&mut self) {
+        self.submitted = true;
+    }
 }
 
 #[keymap(backend = "crossterm")]
@@ -21,6 +77,12 @@ impl TestKeyMap {
     #[keybind(pressed(key=KeyCode::Char('a'), modifiers=KeyModifiers::CONTROL, modifiers=KeyModifiers::SHIFT))]
     fn handle_ctrl_shift_a(&mut self) {
         self.ctrl_shift_a = true;
+    }
+
+    /// Handle Y
+    #[keybind(pressed(key=KeyCode::Char('y')))]
+    fn handle_y(&mut self) {
+        self.y = true;
     }
 }
 
@@ -93,7 +155,7 @@ fn test_ignores_a() {
 
 #[test]
 fn test_keybinds() {
-    assert_eq!(TestKeyMap::KEYBINDS.len(), 2);
+    assert_eq!(TestKeyMap::KEYBINDS.len(), 3);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed.len(), 2);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed[0].key, KeyCode::Esc);
     assert_eq!(
@@ -111,4 +173,29 @@ fn test_keybinds() {
         TestKeyMap::KEYBINDS[1].pressed[0].modifiers,
         KeyModifiers::CONTROL | KeyModifiers::SHIFT
     );
+}
+
+#[test]
+fn test_overlay_keybinds() {
+    let mut map = TestKeyMap::with_active_overlay();
+
+    // Root handles non-conflicting keys with overlay active
+    let event = Event::Key(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
+    assert!(map.handle(&event));
+    assert!(map.ctrl_shift_a);
+
+    // Overlay consumes conflicting key, submits, and is dismissed
+    let event = Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+    assert!(map.handle(&event));
+    assert!(!map.y);
+    assert!(map.submitted);
+    assert!(map.confirmation_overlay.is_none());
+
+    // With overlay dismissed, conflicting keys pass through to root
+    let event = Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+    assert!(map.handle(&event));
+    assert!(map.y);
 }

--- a/tests/crossterm_test.rs
+++ b/tests/crossterm_test.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "crossterm")]
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-use ratatui_input_manager::{keymap, KeyMap};
+use ratatui_input_manager::{KeyMap, keymap};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct TestKeyMap {
@@ -29,7 +29,7 @@ fn test_handle_escape() {
     let mut map = TestKeyMap::default();
 
     let event = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-    map.handle(&event);
+    assert!(map.handle(&event));
 
     assert_eq!(
         TestKeyMap {
@@ -45,7 +45,7 @@ fn test_handle_q() {
     let mut map = TestKeyMap::default();
 
     let event = Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
-    map.handle(&event);
+    assert!(map.handle(&event));
 
     assert_eq!(
         TestKeyMap {
@@ -64,7 +64,7 @@ fn test_handle_ctrl_shift_a() {
         KeyCode::Char('a'),
         KeyModifiers::CONTROL | KeyModifiers::SHIFT,
     ));
-    map.handle(&event);
+    assert!(map.handle(&event));
 
     assert_eq!(
         TestKeyMap {
@@ -80,7 +80,7 @@ fn test_ignores_a() {
     let mut map = TestKeyMap::default();
 
     let event = Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
-    map.handle(&event);
+    assert!(!map.handle(&event));
 
     assert_eq!(
         TestKeyMap {

--- a/tests/termion_test.rs
+++ b/tests/termion_test.rs
@@ -1,11 +1,53 @@
 #![cfg(feature = "termion")]
-use ratatui_input_manager::{keymap, KeyMap};
+use ratatui_input_manager::{KeyMap, keymap};
 use termion::event::{Event, Key};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TestConfirmationOverlayKeyMap {
+    accepted: Option<bool>,
+}
+
+#[keymap(backend = "termion")]
+impl TestConfirmationOverlayKeyMap {
+    /// Handle y to accept
+    #[keybind(pressed(key = Key::Char('y')))]
+    fn handle_accept(&mut self) {
+        self.accepted = Some(true);
+    }
+
+    /// Handle n to reject
+    #[keybind(pressed(key = Key::Char('n')))]
+    fn handle_reject(&mut self) {
+        self.accepted = Some(false);
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct TestKeyMap {
     exit: bool,
     a: bool,
+    y: bool,
+
+    confirmation_overlay: Option<TestConfirmationOverlayKeyMap>,
+}
+
+impl TestKeyMap {
+    fn with_active_overlay() -> TestKeyMap {
+        TestKeyMap {
+            confirmation_overlay: Some(TestConfirmationOverlayKeyMap { accepted: None }),
+            ..Default::default()
+        }
+    }
+
+    fn handle(&mut self, event: &Event) -> bool {
+        if let Some(overlay) = &mut self.confirmation_overlay
+            && overlay.handle(event) {
+                self.confirmation_overlay = None;
+                return true;
+            }
+
+        KeyMap::handle(self, event)
+    }
 }
 
 #[keymap(backend = "termion")]
@@ -21,6 +63,12 @@ impl TestKeyMap {
     #[keybind(pressed(key = Key::Char('a')))]
     fn handle_a(&mut self) {
         self.a = true;
+    }
+
+    /// Handle y key
+    #[keybind(pressed(key = Key::Char('y')))]
+    fn handle_y(&mut self) {
+        self.y = true;
     }
 }
 
@@ -74,7 +122,7 @@ fn test_handle_a() {
 
 #[test]
 fn test_keybinds() {
-    assert_eq!(TestKeyMap::KEYBINDS.len(), 2);
+    assert_eq!(TestKeyMap::KEYBINDS.len(), 3);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed.len(), 2);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed[0].key, Key::Esc);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed[0].modifiers, ());
@@ -83,4 +131,23 @@ fn test_keybinds() {
     assert_eq!(TestKeyMap::KEYBINDS[1].pressed.len(), 1);
     assert_eq!(TestKeyMap::KEYBINDS[1].pressed[0].key, Key::Char('a'));
     assert_eq!(TestKeyMap::KEYBINDS[1].pressed[0].modifiers, ());
+}
+
+#[test]
+fn test_overlay_keybinds() {
+    let mut map = TestKeyMap::with_active_overlay();
+
+    // Root handles non-conflicting keys with overlay active
+    let event = Event::Key(Key::Char('a'));
+    assert!(map.handle(&event));
+    assert!(map.a);
+
+    // Overlay consumes conflicting key and is dismissed
+    let event = Event::Key(Key::Char('y'));
+    assert!(map.handle(&event));
+    assert!(!map.y);
+
+    // With overlay dismissed, conflicting key passes through to root
+    assert!(map.handle(&event));
+    assert!(map.y);
 }

--- a/tests/termwiz_test.rs
+++ b/tests/termwiz_test.rs
@@ -1,11 +1,53 @@
 #![cfg(feature = "termwiz")]
-use ratatui_input_manager::{keymap, KeyMap};
+use ratatui_input_manager::{KeyMap, keymap};
 use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TestConfirmationOverlayKeyMap {
+    accepted: Option<bool>,
+}
+
+#[keymap(backend = "termwiz")]
+impl TestConfirmationOverlayKeyMap {
+    /// Handle y to accept
+    #[keybind(pressed(key=KeyCode::Char('y')))]
+    fn handle_accept(&mut self) {
+        self.accepted = Some(true);
+    }
+
+    /// Handle n to reject
+    #[keybind(pressed(key=KeyCode::Char('n')))]
+    fn handle_reject(&mut self) {
+        self.accepted = Some(false);
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct TestKeyMap {
     exit: bool,
     ctrl_shift_a: bool,
+    y: bool,
+
+    confirmation_overlay: Option<TestConfirmationOverlayKeyMap>,
+}
+
+impl TestKeyMap {
+    fn with_active_overlay() -> TestKeyMap {
+        TestKeyMap {
+            confirmation_overlay: Some(TestConfirmationOverlayKeyMap { accepted: None }),
+            ..Default::default()
+        }
+    }
+
+    fn handle(&mut self, event: &InputEvent) -> bool {
+        if let Some(overlay) = &mut self.confirmation_overlay
+            && overlay.handle(event) {
+                self.confirmation_overlay = None;
+                return true;
+            }
+
+        KeyMap::handle(self, event)
+    }
 }
 
 #[keymap(backend = "termwiz")]
@@ -21,6 +63,12 @@ impl TestKeyMap {
     #[keybind(pressed(key=KeyCode::Char('a'), modifiers=Modifiers::CTRL, modifiers=Modifiers::SHIFT))]
     fn handle_ctrl_shift_a(&mut self) {
         self.ctrl_shift_a = true;
+    }
+
+    /// Handle y key
+    #[keybind(pressed(key=KeyCode::Char('y')))]
+    fn handle_y(&mut self) {
+        self.y = true;
     }
 }
 
@@ -102,7 +150,7 @@ fn test_ignores_a() {
 
 #[test]
 fn test_keybinds() {
-    assert_eq!(TestKeyMap::KEYBINDS.len(), 2);
+    assert_eq!(TestKeyMap::KEYBINDS.len(), 3);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed.len(), 2);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed[0].key, KeyCode::Escape,);
     assert_eq!(TestKeyMap::KEYBINDS[0].pressed[1].key, KeyCode::Char('q'),);
@@ -120,4 +168,29 @@ fn test_keybinds() {
         TestKeyMap::KEYBINDS[1].pressed[0].modifiers,
         Modifiers::CTRL | Modifiers::SHIFT
     );
+}
+
+#[test]
+fn test_overlay_keybinds() {
+    let mut map = TestKeyMap::with_active_overlay();
+
+    // Root handles non-conflicting keys with overlay active
+    let event = InputEvent::Key(KeyEvent {
+        key: KeyCode::Char('a'),
+        modifiers: Modifiers::CTRL | Modifiers::SHIFT,
+    });
+    assert!(map.handle(&event));
+    assert!(map.ctrl_shift_a);
+
+    // Overlay consumes conflicting key and is dismissed
+    let event = InputEvent::Key(KeyEvent {
+        key: KeyCode::Char('y'),
+        modifiers: Modifiers::NONE,
+    });
+    assert!(map.handle(&event));
+    assert!(!map.y);
+
+    // With overlay dismissed, conflicting key passes through to root
+    assert!(map.handle(&event));
+    assert!(map.y);
 }


### PR DESCRIPTION
This would be useful for handling nested keymaps, allowing conditionally passing the key to the root app only if the current overlay did not use it. For example: https://github.com/GDYendell/pomo-tui/pull/14

- [x] Needs tests and docs if accepted